### PR TITLE
Add editorconfig file

### DIFF
--- a/generators/app/index.js
+++ b/generators/app/index.js
@@ -214,6 +214,10 @@ module.exports = fountain.Base.extend({
           / {2}return gulp\.src[^\n]*/
         );
       }
+      this.copyTemplate(
+        '.editorconfig',
+        '.editorconfig'
+      );
     }
   }
 });

--- a/generators/app/templates/.editorconfig
+++ b/generators/app/templates/.editorconfig
@@ -1,0 +1,8 @@
+root = true
+
+[*]
+indent_style = space
+indent_size = 2
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true

--- a/test/app/index.writing.js
+++ b/test/app/index.writing.js
@@ -14,21 +14,25 @@ test.before(() => {
 });
 
 test('Wiring with angular1/webpack/babel', () => {
-  const spy = chai.spy.on(context, 'replaceInFileWithTemplate');
+  const spy1 = chai.spy.on(context, 'replaceInFileWithTemplate');
+  const spy2 = chai.spy.on(context, 'copyTemplate');
   TestUtils.call(context, 'writing.wiring', {framework: 'angular1', modules: 'webpack', js: 'babel'});
-  expect(spy).to.have.been.called.twice();
+  expect(spy1).to.have.been.called.twice();
+  expect(spy2).to.have.been.called.once();
 });
 
 test('Wiring with angular2/systemjs', () => {
   const spy = chai.spy.on(context, 'copyTemplate');
   TestUtils.call(context, 'writing.wiring', {framework: 'angular2', modules: 'systemjs'});
-  expect(spy).to.have.been.called.once();
+  expect(spy).to.have.been.called.twice(2);
 });
 
 test('Wiring with angular1/inject/js', () => {
-  const spy = chai.spy.on(context, 'replaceInFileWithTemplate');
+  const spy1 = chai.spy.on(context, 'replaceInFileWithTemplate');
+  const spy2 = chai.spy.on(context, 'copyTemplate');
   TestUtils.call(context, 'writing.wiring', {framework: 'angular1', modules: 'inject', js: 'js'});
-  expect(spy).to.have.been.called.twice();
+  expect(spy1).to.have.been.called.twice();
+  expect(spy2).to.have.been.called.once();
 });
 
 test('Wiring with react/webpack/typescript', () => {
@@ -36,5 +40,5 @@ test('Wiring with react/webpack/typescript', () => {
   const spy2 = chai.spy.on(context, 'copyTemplate');
   TestUtils.call(context, 'writing.wiring', {framework: 'react', modules: 'webpack', js: 'typescript'});
   expect(spy1).to.have.been.called.exactly(0);
-  expect(spy2).to.have.been.called.exactly(0);
+  expect(spy2).to.have.been.called.once();
 });


### PR DESCRIPTION
I noticed there isn't *editorconfig* file in generated project by fountainjs. It may be delibarate.
As *xo-linter* with *xo-space* is very strict, I think that adding *editorconfig* would simplify developement.
