### PR TITLE
Disable angular/no-service-method

### DIFF
--- a/generators/app/index.js
+++ b/generators/app/index.js
@@ -22,6 +22,11 @@ module.exports = fountain.Base.extend({
           devDependencies: {
             'eslint-config-angular': '^0.5.0',
             'eslint-plugin-angular': '^1.3.0'
+          },
+          eslintConfig: {
+            rules: {
+              'angular/no-service-method': 0
+            }
           }
         });
       }

--- a/test/utils.js
+++ b/test/utils.js
@@ -37,6 +37,11 @@ module.exports.angular1Base = {
   devDependencies: {
     'eslint-config-angular': '^0.5.0',
     'eslint-plugin-angular': '^1.3.0'
+  },
+  eslintConfig: {
+    rules: {
+      'angular/no-service-method': 0
+    }
   }
 };
 


### PR DESCRIPTION
Disable ESLint rule `angular/no-service-method` which advises to use `.factory()` instead of `.service()` (http://blog.thoughtram.io/angular/2015/07/07/service-vs-factory-once-and-for-all.html)
Fixes https://travis-ci.org/FountainJS/fountain/jobs/153595426